### PR TITLE
user-profile-image

### DIFF
--- a/src/components/Leaderboard/TabContent.js
+++ b/src/components/Leaderboard/TabContent.js
@@ -13,8 +13,13 @@ export const TabContent = ({
       {Object.entries(data).map((user, i) => (
         <InfoBox key={i} backgroundColor={(index-1) === i ? COLOR.MANDARIN : null}>
           <Body>{i+1}</Body>
-          <UserImg backgroundColor={user[1].profile_image ? null : COLOR.ISLAND_SPICE}>
-            {user[1].profile_image ? <img src={user[1].profile_image}/> : null}
+          <UserImg backgroundColor={user[1].profileImage ? null : COLOR.ISLAND_SPICE}>
+            {user[1].profileImage ? (
+                <img
+                  style={{ width: "40px", height: "40px", borderRadius: "50%" }}
+                  src={"data:image/png;base64," + user[1].profileImage.data}
+                />
+              ) : null}
           </UserImg>
           <Body>{user[1].username}</Body>
           <LevelText color={(index-1) === i ? COLOR.ISLAND_SPICE : COLOR.GOLDEN_TAINOI}> Lv.{user[1].level}</LevelText>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -73,7 +73,7 @@ const Navbar = ({
           backgroundColor={user_info.photo ? null : COLOR.ISLAND_SPICE} 
           onClick={handleClickProfileImage}
         >
-          {user_info.photo ? <Image src={user_info.photo}/> : null}
+          {user_info.photo ? <Image src={"data:image/png;base64,"+user_info.photo.data}/> : null}
         </ProfileImage>
       </InfoContainer>
     </Container>

--- a/src/containers/AllChallengePage/AllChallengePageHelper.js
+++ b/src/containers/AllChallengePage/AllChallengePageHelper.js
@@ -99,8 +99,8 @@ export const useRandomChallenge = (user_id, subject, subtopic_name, difficulty) 
       const { success, data } = response.data;
       if (success) {
         set_challenge_id(data.challengeId);
-        set_me(data.user1);
-        set_opponent(data.user2);
+        set_me(data.user1[0]);
+        set_opponent(data.user2[0]);
         set_loading(false);
       } else {
         console.log("random challenge Error");

--- a/src/containers/AllChallengePage/components/ChallengeBox.js
+++ b/src/containers/AllChallengePage/components/ChallengeBox.js
@@ -33,7 +33,7 @@ export const ChallengeBox = ({
     <div style={{ marginTop: 12, marginRight: margin_right }} onClick={onClick}>
       <ItemBox type = "small" color={is_read ? COLOR.WHITE : convertHexToRGBA(COLOR.ISLAND_SPICE, 45)} width={96}>
         <ProfileImage backgroundColor={image ? null : COLOR.ISLAND_SPICE}>
-          {image ? <Image src={image}/> : null}
+          {image ? <Image src={"data:image/png;base64,"+image.data}/> : null}
         </ProfileImage>
         <div style={{ marginTop: 4 }}>
           <Overline>{username}</Overline>

--- a/src/containers/AllChallengePage/components/RandomChallengeModal.js
+++ b/src/containers/AllChallengePage/components/RandomChallengeModal.js
@@ -121,7 +121,7 @@ export const RandomChallengeModal = ({
                       height: "80px",
                       borderRadius: "50%",
                     }}
-                    src={"data:image/png;base64," + opponent_profile_img}
+                    src={"data:image/png;base64," + opponent_profile_img.data}
                   />
                 ) : null}
               </UserImg>

--- a/src/containers/AllChallengePage/components/RandomChallengeModal.js
+++ b/src/containers/AllChallengePage/components/RandomChallengeModal.js
@@ -59,22 +59,23 @@ export const RandomChallengeModal = ({
 
   return (
     <div>
-      <Modal
-        isShowing={isShowing}
-        hide={toggle}
-      >
-        <Container
-          initial="hidden"
-          animate="visible"
-          variants={list}
-        >
+      <Modal isShowing={isShowing} hide={toggle}>
+        <Container initial="hidden" animate="visible" variants={list}>
           <ImgWithCaption>
-            <motion.div 
-              variants={variants}
-              style= {{alignSelf: "center"}}
-            >
-              <UserImg backgroundColor={my_profile_img ? null : COLOR.ISLAND_SPICE}>
-                {my_profile_img ? <img src={my_profile_img}/> : null}
+            <motion.div variants={variants} style={{ alignSelf: "center" }}>
+              <UserImg
+                backgroundColor={my_profile_img ? null : COLOR.ISLAND_SPICE}
+              >
+                {my_profile_img ? (
+                  <img
+                    style={{
+                      width: "80px",
+                      height: "80px",
+                      borderRadius: "50%",
+                    }}
+                    src={"data:image/png;base64," + my_profile_img.data}
+                  />
+                ) : null}
               </UserImg>
             </motion.div>
             <motion.div variants={variants}>
@@ -83,27 +84,46 @@ export const RandomChallengeModal = ({
               </Body>
             </motion.div>
           </ImgWithCaption>
-          <motion.div 
+          <motion.div
             variants={variants}
-            style = {{marginTop: "8px", marginBottom:"8px", width:"150px", height:"75px", alignSelf: "center" }}
+            style={{
+              marginTop: "8px",
+              marginBottom: "8px",
+              width: "150px",
+              height: "75px",
+              alignSelf: "center",
+            }}
           >
             {display_lottie && (
-              <LottieFile 
-                animationData={challenge} 
-                width="150px" 
-                height="75px" 
+              <LottieFile
+                animationData={challenge}
+                width="150px"
+                height="75px"
                 loop={false}
               />
             )}
-          </motion.div> 
+          </motion.div>
           <ImgWithCaption alignSelf={"flex-end"}>
-            <motion.div 
+            <motion.div
               variants={item}
-              custom={4} 
-              style= {{alignSelf: "center"}}
+              custom={4}
+              style={{ alignSelf: "center" }}
             >
-              <UserImg backgroundColor={opponent_profile_img ? null : COLOR.ISLAND_SPICE}>
-                {opponent_profile_img ? <img src={opponent_profile_img}/> : null}
+              <UserImg
+                backgroundColor={
+                  opponent_profile_img ? null : COLOR.ISLAND_SPICE
+                }
+              >
+                {opponent_profile_img ? (
+                  <img
+                    style={{
+                      width: "80px",
+                      height: "80px",
+                      borderRadius: "50%",
+                    }}
+                    src={"data:image/png;base64," + opponent_profile_img}
+                  />
+                ) : null}
               </UserImg>
             </motion.div>
             <motion.div variants={item} custom={5}>
@@ -112,10 +132,14 @@ export const RandomChallengeModal = ({
               </Body>
             </motion.div>
           </ImgWithCaption>
-          <motion.div 
+          <motion.div
             variants={item}
-            custom={6} 
-            style = {{display: "flex", justifyContent: "center" ,marginTop: "24px"}}
+            custom={6}
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              marginTop: "24px",
+            }}
           >
             <Button onClick={onSubmit}> ยืนยัน </Button>
           </motion.div>

--- a/src/containers/ChallengeGamePage/components/UserInfo.js
+++ b/src/containers/ChallengeGamePage/components/UserInfo.js
@@ -17,7 +17,7 @@ export const UserInfo = ({
     <ProfileImageContainer>
       <UserInfoContainer>
         <ProfileImage backgroundColor={my_image ? null : COLOR.ISLAND_SPICE}>
-          {my_image ? <Image src={my_image}/> : null}
+          {my_image ? <Image src={"data:image/png;base64,"+my_image.data}/> : null}
         </ProfileImage>
         <div style={{ marginBottom: 4 }}/>
         <Body color={COLOR.MANDARIN}>{my_score}</Body>
@@ -27,7 +27,7 @@ export const UserInfo = ({
       </VSContainer>
       <UserInfoContainer>
         <ProfileImage backgroundColor={challenger_image ? null : COLOR.ISLAND_SPICE}>
-          {challenger_image ? <Image src={challenger_image}/> : null}
+          {challenger_image ? <Image src={"data:image/png;base64,"+challenger_image.data}/> : null}
         </ProfileImage>
         <div style={{ marginBottom: 4 }}/>
         {challenger_is_played

--- a/src/containers/ChallengeResultPage/components/UserInfoBox.js
+++ b/src/containers/ChallengeResultPage/components/UserInfoBox.js
@@ -47,52 +47,49 @@ export const UserInfoBox = ({
   }
 
   return (
-       <UserInfoContainer
-        initial="hidden"
-        animate="visible"
-        variants={list} 
-      >
-        <UserInfo>
-          <UserImg
-            custom={1} 
-            variants={variants}  
-            backgroundColor={profile_image ? null : COLOR.ISLAND_SPICE}
-          >
-              {profile_image ? <img src={profile_image}/> : null}
-          </UserImg>
-          <motion.div
-            custom={2} 
-            variants={variants}
-          >
-            <Body> {username} </Body>
-          </motion.div>
-        </UserInfo>
-        <ScoreBox
-          custom={3} 
-          variants={variants} 
+    <UserInfoContainer initial="hidden" animate="visible" variants={list}>
+      <UserInfo>
+        <UserImg
+          custom={1}
+          variants={variants}
+          backgroundColor={profile_image ? null : COLOR.ISLAND_SPICE}
         >
-          {challenge_result.map((result, index)=> (
-            <Icon
-              key={index}
-              custom={index+4} 
-              variants={variants}
-              src={result ? correct_icon: incorrect_icon}
+          {profile_image ? (
+            <img
+              style={{ width: "48px", height: "48px", borderRadius: "50%" }}
+              src={"data:image/png;base64," + profile_image.data}
             />
-          ))}
-          <motion.div 
-            custom={NUMBER_OF_PROBLEM+4} 
-            variants={variants} 
-          >
-            <Header props color = {COLOR.MANDARIN}>{total_score}</Header> 
-          </motion.div>
-        </ScoreBox>
-        <motion.div
-            custom={NUMBER_OF_PROBLEM+5} 
+          ) : null}
+        </UserImg>
+        <motion.div custom={2} variants={variants}>
+          <Body> {username} </Body>
+        </motion.div>
+      </UserInfo>
+      <ScoreBox custom={3} variants={variants}>
+        {challenge_result.map((result, index) => (
+          <Icon
+            key={index}
+            custom={index + 4}
             variants={variants}
-            style={{marginTop: "8px"}}
-          >
-            <Overline props color={COLOR.MANDARIN}> เวลาที่ใช้: {secondToHour(time)} </Overline>
-          </motion.div>
+            src={result ? correct_icon : incorrect_icon}
+          />
+        ))}
+        <motion.div custom={NUMBER_OF_PROBLEM + 4} variants={variants}>
+          <Header props color={COLOR.MANDARIN}>
+            {total_score}
+          </Header>
+        </motion.div>
+      </ScoreBox>
+      <motion.div
+        custom={NUMBER_OF_PROBLEM + 5}
+        variants={variants}
+        style={{ marginTop: "8px" }}
+      >
+        <Overline props color={COLOR.MANDARIN}>
+          {" "}
+          เวลาที่ใช้: {secondToHour(time)}{" "}
+        </Overline>
+      </motion.div>
     </UserInfoContainer>
   );
 };

--- a/src/containers/Homepage/HomepageHelper.js
+++ b/src/containers/Homepage/HomepageHelper.js
@@ -36,7 +36,6 @@ export const useGetLeaderBoard = (user_id) => {
         }
       );
       const { success, data } = response.data;
-      console.log(data)
       if (success) {
         set_leader_board(data);
         set_leader_board_loading(false);

--- a/src/containers/Homepage/components/SubjectCard.js
+++ b/src/containers/Homepage/components/SubjectCard.js
@@ -7,6 +7,7 @@ import { convertHexToRGBA } from "../../../global/utils";
 // Global
 import { COLOR } from "../../../global/const";
 import { Header } from "../../../components/Typography";
+import default_topic from "../../../assets/thumbnail/default_topic.png";
 import { withRouter } from "react-router-dom";
 
 const subject_box_shadow = convertHexToRGBA(`${COLOR.BLACK}`, 25);
@@ -36,7 +37,7 @@ const SubjectCard = ({ history, subjects_data }) => {
               handleOnSubjectClick(subject._id);
             }}
           >
-            <SubjectImg src={subject.subjectImg} />
+            <SubjectImg src={subject.subjectImg ? subject.subjectImg : default_topic} />
             <Header>{subject._id}</Header>
           </SubjectBox>
         );

--- a/src/containers/ProfilePage/ProfilePage.js
+++ b/src/containers/ProfilePage/ProfilePage.js
@@ -61,7 +61,7 @@ const ProfilePage = ({ history, handleLogout, user_info }) => {
                   />
                   <img src={photo} height={100} width={100}/>
                 </div>
-              : user_info.photo ? <Image src={user_info.photo}/> : null
+              : user_info.photo ? <Image src={"data:image/png;base64,"+user_info.photo.data}/> : null
             }
           </ProfileImage>
           <UsernameContainer>


### PR DESCRIPTION
รันกับ backend branch nutnut นะ
คำถาม: มีหน้าไหนนอกจากนี้อีกมั้ยที่ใช้

update: 
- fixed display opponent profile image in random challenge modal 
- ใส่ default ให้ subject ถ้ารูปเป็น null
- leaderboard profile img

<img width="349" alt="Screen Shot 2564-01-20 at 15 55 17" src="https://user-images.githubusercontent.com/42530415/105151122-28753c00-5b38-11eb-9dd6-39508a97b5d7.png">
<img width="312" alt="Screen Shot 2564-01-20 at 19 46 40" src="https://user-images.githubusercontent.com/42530415/105176771-4357a880-5b58-11eb-9d4a-6971e628797e.png">

<img width="312" alt="Screen Shot 2564-01-20 at 19 33 26" src="https://user-images.githubusercontent.com/42530415/105175398-6f722a00-5b56-11eb-8695-a09ae03befb7.png">

- Profile + Navbar
<img width="320" alt="Screen Shot 2564-01-20 at 11 28 07" src="https://user-images.githubusercontent.com/42530415/105131133-edb0db00-5b1a-11eb-91ac-dcfd6296fc9f.png">

- Challenge game => getChallengeInfo

<img width="320" alt="Screen Shot 2564-01-20 at 11 27 53" src="https://user-images.githubusercontent.com/42530415/105131286-38caee00-5b1b-11eb-89b8-1b024a1a1ca7.png">

- Random challenge => randomChallenge
<img width="305" alt="Screen Shot 2564-01-20 at 13 21 20" src="https://user-images.githubusercontent.com/42530415/105135301-66676580-5b22-11eb-9945-293dae4f8859.png">

- All challenge (opponent image) => getALLMyChallenges

<img width="320" alt="Screen Shot 2564-01-20 at 12 29 09" src="https://user-images.githubusercontent.com/42530415/105131233-1c2eb600-5b1b-11eb-9f44-c8fa2f34aa08.png">

- Challenge result => getFinalChallengeResult

<img width="320" alt="Screen Shot 2564-01-20 at 12 16 12" src="https://user-images.githubusercontent.com/42530415/105131256-2781e180-5b1b-11eb-909f-1227b01ae367.png">
